### PR TITLE
Update for latest ASX website

### DIFF
--- a/R/option-chain.R
+++ b/R/option-chain.R
@@ -38,11 +38,16 @@ getOptionChainAsx <- function(symbol) {
   #   return(NULL)
   # }
 
+  #
+  # Remove all whitespace in colnames (some contain \n\t)
+  #
+  colnames(html[[index]]) <- gsub("\\s+", "", colnames(html[[index]]))
+
   # Use the second element in the list (the first element gives data on the underlying stock)
   #
   options = html[[index]] %>%
     rename(c("Bid" = "bid", "Offer" = "ask", "Openinterest" = "open.interest", "Volume" = "volume", "Expirydate" = "expiry",
-             "P/C" = "type", "Margin Price" = "premium", "Exercise" = "strike")) %>%
+             "P/C" = "type", "MarginPrice" = "premium", "Exercise" = "strike")) %>%
     transform(
       symbol        = symbol,
       retrieved     = Sys.time(),


### PR DESCRIPTION
I was trying to use `getOptionChain` for some ASX symbols and it was failing because I assume they've changed their website ever so slightly.

Some of the columns currently come through with newlines and tabs in the middle so I just stripped all the space out of column names, I'm an R newbie so no idea if what I did is the best way. I figured this was probably more robust against further changes than using `"Expiry\n\t\t\t\tdate"` directly, but could also do that too. :man_shrugging:

colnames before gsub:
```
 [1] "Code"                   "Expiry\n\t\t\t\tdate"   "P/C"                    "Exercise"              
 [5] "Bid"                    "Offer"                  "Last"                   "Volume"                
 [9] "Open\n\t\t\t\tinterest" "Margin\n\t\t\t\tPrice" 
```
after:
```
 [1] "Code"         "Expirydate"   "P/C"          "Exercise"     "Bid"          "Offer"       
 [7] "Last"         "Volume"       "Openinterest" "MarginPrice" 
```